### PR TITLE
Layer-Free RBLPopover

### DIFF
--- a/Rebel/RBLPopover.h
+++ b/Rebel/RBLPopover.h
@@ -166,9 +166,6 @@ typedef void (^RBLPopoverDelegateBlock)(RBLPopover *popover);
 // The edge of the target view which the popover is appearing next to.
 @property (nonatomic) CGRectEdge popoverEdge;
 
-// The color used to stroke the outline of the background view.
-@property (nonatomic, strong) NSColor *strokeColor;
-
 // The color used to fill the shape of the background view.
 @property (nonatomic, strong) NSColor *fillColor;
 

--- a/Rebel/RBLPopover.m
+++ b/Rebel/RBLPopover.m
@@ -483,7 +483,6 @@ static CGFloat const RBLPopoverBackgroundViewArrowWidth = 35.0;
 	
 	_popoverEdge = popoverEdge;
 	_screenOriginRect = originScreenRect;
-	_strokeColor = NSColor.redColor;
 	_fillColor = NSColor.whiteColor;
 	
 	return self;


### PR DESCRIPTION
This changes the popover to no longer rely on a layer backed background view.

As a side effect we also get rid of the weird "content view" subclass which existed solely so we could get a shadow.
