### PR TITLE
Use layer hosting instead of layer backing for RBLClipView

### DIFF
--- a/Rebel/RBLClipView.m
+++ b/Rebel/RBLClipView.m
@@ -37,7 +37,9 @@
 	self = [super initWithFrame:frame];
 	if (self == nil) return nil;
 
+	self.layer = [CAScrollLayer layer];
 	self.wantsLayer = YES;
+
 	self.layerContentsRedrawPolicy = NSViewLayerContentsRedrawNever;
 
 	// Matches default NSClipView settings.
@@ -45,12 +47,6 @@
 	self.opaque = NO;
 
 	return self;
-}
-
-#pragma mark Backing Layer
-
-- (CALayer *)makeBackingLayer {
-	return [CAScrollLayer layer];
 }
 
 @end


### PR DESCRIPTION
Layer-backing results in the clip view sometimes turning completely
white on 10.7 (with `drawsBackground` enabled, regardless of the actual
`backgroundColor`).
