### PR TITLE
Change how we draw the popover background.

### DIFF
--- a/Rebel/RBLPopover.m
+++ b/Rebel/RBLPopover.m
@@ -493,13 +493,8 @@ static CGFloat const RBLPopoverBackgroundViewArrowWidth = 35.0;
 
 - (void)drawRect:(NSRect)rect {
 	[super drawRect:rect];
-	CGContextRef context = NSGraphicsContext.currentContext.graphicsPort;
-	CGPathRef outerBorder = [self newPopoverPathForEdge:self.popoverEdge inFrame:self.bounds];
-	CGContextSetFillColorWithColor(context, self.fillColor.rbl_CGColor);
-	CGContextAddPath(context, outerBorder);
-	CGContextFillPath(context);
-	
-	CGPathRelease(outerBorder);
+	[self.fillColor set];
+	NSRectFill(rect);
 }
 
 - (CGRectEdge)arrowEdgeForPopoverEdge:(CGRectEdge)popoverEdge {


### PR DESCRIPTION
Since the clipping view we don't need to draw the background into a
specific path, just fill and let the clipping view take care of the
work.

This fixes a certain issue on Mac… which I'm not sure I should link considering this will be public :p.
