### PR TITLE
Rebuild the popover if the popover edge changes.

### DIFF
--- a/Rebel/RBLPopover.m
+++ b/Rebel/RBLPopover.m
@@ -213,8 +213,13 @@ static NSTimeInterval const RBLPopoverDefaultFadeDuration = 0.3;
 	CGRect popoverScreenRect = popoverRect();
 	
 	if (self.shown) {
-		[self.popoverWindow setFrame:popoverScreenRect display:YES];
-		return;
+		if (self.backgroundView.popoverEdge == popoverEdge) {
+			[self.popoverWindow setFrame:popoverScreenRect display:YES];
+			return;
+		}
+		
+		[self.popoverWindow close];
+		self.popoverWindow = nil;
 	}
 	
 	//TODO: Create RBLViewController with viewWillAppear


### PR DESCRIPTION
This fixes the popover getting all out of whack when getting repositioned but wanting to use a different `popoverEdge`.
