### PR TITLE
Use our emerging script/bootstrap standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This framework also contains more general (not MVVM-specific) additions to fix b
 
 ## Getting Started
 
-To start building the framework, clone this repository and then run `git submodule update --init --recursive`. This will automatically pull down any dependencies.
+To start building the framework, clone this repository and then run `script/bootstrap`. This will automatically pull down any dependencies.
 
 ## Contributing
 

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Ensure local dependencies are up to date.
+
+cd $(dirname "$0")/..
+
+git submodule update --init --recursive


### PR DESCRIPTION
This encapsulates our `git submodule` call into a `script/bootstrap` executable. This matches the dependency approach of many of our other projects and gives us a place to hook more bootstrapping up if it's ever necessary.
