### PR TITLE
Popover window should act like a key window.

### DIFF
--- a/Rebel/RBLPopover.m
+++ b/Rebel/RBLPopover.m
@@ -19,14 +19,6 @@
 
 @end
 
-@implementation RBLPopoverWindow
-
-- (BOOL)isKeyWindow {
-	return YES;
-}
-
-@end
-
 //***************************************************************************
 
 @interface RBLPopoverBackgroundView ()
@@ -97,6 +89,16 @@ static NSTimeInterval const RBLPopoverDefaultFadeDuration = 0.3;
 	CGContextSetBlendMode(currentContext, kCGBlendModeCopy);
 	[NSColor.clearColor set];
 	CGContextEOFillPath(currentContext);
+}
+
+@end
+
+//***************************************************************************
+
+@implementation RBLPopoverWindow
+
+- (BOOL)isKeyWindow {
+	return YES;
 }
 
 @end


### PR DESCRIPTION
Sorry about the mistakes in #39. I've just realized that a window doesn't need to become key window to receive mouseMoved events. It just need to act like a key window by always returning `YES` in its `isKeyWindow` method.

So in this PR, I still subclass the NSWindow but override the `isKeyWindow` method instead. Now, when the popover is presented, the main window will remain key  status to receive keyboard events and such. While the popover is faking itself as a key window to receive mouseMoved events.
