### PR TITLE
Layer-back RBLScrollView

### DIFF
--- a/Rebel/RBLScrollView.h
+++ b/Rebel/RBLScrollView.h
@@ -10,6 +10,8 @@
 
 // A NSScrollView subclass which uses an instance of RBLClipView
 // as the clip view instead of NSClipView.
+//
+// Layer-backed by default.
 @interface RBLScrollView : NSScrollView
 
 @end

--- a/Rebel/RBLScrollView.m
+++ b/Rebel/RBLScrollView.m
@@ -33,6 +33,7 @@
 #pragma mark Clip view swapping
 
 - (void)swapClipView {
+	self.wantsLayer = YES;
 	id documentView = self.documentView;
 	RBLClipView *clipView = [[RBLClipView alloc] initWithFrame:self.contentView.frame];
 	self.contentView = clipView;


### PR DESCRIPTION
I noticed some issues when the scroll view wasn't layer-backed by default and had a `RBLClipView` as the clip view. There was corruption on the top when bouncing.
