### PR TITLE
Don't hide popover if it currently displays an alert sheet.

### DIFF
--- a/Rebel/RBLPopover.m
+++ b/Rebel/RBLPopover.m
@@ -241,6 +241,8 @@
 		
 		self.transientEventMonitor = [NSEvent addLocalMonitorForEventsMatchingMask:(NSLeftMouseDownMask | NSRightMouseDownMask | NSKeyUpMask) handler: ^(NSEvent *event) {
 			if (self.popoverWindow == nil) return event;
+  
+      if ( self.popoverWindow.attachedSheet ) return event;
 			
 			static NSUInteger escapeKey = 53;
 			BOOL shouldClose = NO;


### PR DESCRIPTION
It would lead to a crash if a delegate has been set.
