### PR TITLE
Fix flippedness bug drawing vertical 3 part images.

### DIFF
--- a/Rebel/RBLResizableImage.m
+++ b/Rebel/RBLResizableImage.m
@@ -135,7 +135,7 @@
 		NSDrawThreePartImage(dstRect, leftEdge, center, rightEdge, NO, op, alpha, flipped);
 	} else {
 		// Vertical three-part image.
-		NSDrawThreePartImage(dstRect, topEdge, center, bottomEdge, YES, op, alpha, flipped);
+		NSDrawThreePartImage(dstRect, (flipped ? bottomEdge : topEdge), center, (flipped ? topEdge : bottomEdge), YES, op, alpha, flipped);
 	}
 }
 


### PR DESCRIPTION
Fixes #77

See [NSDrawThreePartImage](https://developer.apple.com/library/mac/documentation/Cocoa/Reference/ApplicationKit/Miscellaneous/AppKit_Functions/Reference/reference.html#//apple_ref/doc/uid/20000695-SW62).
