### PR TITLE
Fixes responder chain

### DIFF
--- a/Rebel/NSView+RBLViewControllerAdditions.m
+++ b/Rebel/NSView+RBLViewControllerAdditions.m
@@ -26,7 +26,7 @@ void *kRBLViewControllerKey = &kRBLViewControllerKey;
 	
 	if (self.rbl_viewController) {
 		NSResponder *controllerNextResponder = [self.rbl_viewController nextResponder];
-		[self setNextResponder:controllerNextResponder];
+		[self custom_setNextResponder:controllerNextResponder];
 		[self.rbl_viewController setNextResponder:nil];
 	}
 	
@@ -34,7 +34,7 @@ void *kRBLViewControllerKey = &kRBLViewControllerKey;
 	
 	if (newViewController) {
 		NSResponder *ownResponder = [self nextResponder];
-		[self setNextResponder:self.rbl_viewController];
+		[self custom_setNextResponder:self.rbl_viewController];
 		[self.rbl_viewController setNextResponder:ownResponder];
 	}
 }


### PR DESCRIPTION
I believe there's a bug in the NSView+RBLViewControllerAdditions. In order to insert the rbl_viewController into the responder chain, `setNextResponder:` is called on the view. However, since the swizzling has already happened at this point, this sets the nextResponder on the rbi_viewController instead.
