### PR TITLE
Verify that font descriptors exist before cascading to them

### DIFF
--- a/Rebel/NSFont+RBLFallbackAdditions.m
+++ b/Rebel/NSFont+RBLFallbackAdditions.m
@@ -13,26 +13,43 @@
 + (NSFont *)rbl_fontWithName:(NSString *)fontName size:(CGFloat)fontSize fallbackNames:(NSArray *)fallbackNames {
 	NSParameterAssert(fontName != nil);
 
+	NSSet *mandatoryKeys = [NSSet setWithObjects:NSFontNameAttribute, NSFontSizeAttribute, nil];
 	NSMutableArray *fallbackDescriptors = [NSMutableArray arrayWithCapacity:fallbackNames.count];
+
 	for (NSString *fallbackName in fallbackNames) {
-		[fallbackDescriptors addObject:[NSFontDescriptor fontDescriptorWithName:fallbackName size:fontSize]];
+		// Our ideal fallback font.
+		NSFontDescriptor *searchDescriptor = [NSFontDescriptor fontDescriptorWithName:fallbackName size:fontSize];
+
+		// Now check to see whether a match actually exists, falling back to
+		// a different size if necessary.
+		NSFontDescriptor *matchingDescriptor = [searchDescriptor matchingFontDescriptorWithMandatoryKeys:mandatoryKeys];
+		if (matchingDescriptor == nil) continue;
+
+		[fallbackDescriptors addObject:matchingDescriptor];
 	}
 
 	NSMutableArray *remainingFontNames = [fallbackNames mutableCopy];
-	NSAssert(fallbackDescriptors.count == remainingFontNames.count, @"Should have the same number of fallback font descriptors (%lu) as names to try (%lu)", (unsigned long)fallbackDescriptors.count, (unsigned long)remainingFontNames.count);
+	NSAssert(fallbackDescriptors.count <= remainingFontNames.count, @"Should have no more fallback font descriptors (%lu) than names to try (%lu)", (unsigned long)fallbackDescriptors.count, (unsigned long)remainingFontNames.count);
+
+	NSMutableDictionary *attributes = [NSMutableDictionary dictionary];
+	if (fallbackDescriptors.count > 0) attributes[NSFontCascadeListAttribute] = fallbackDescriptors;
 
 	while (YES) {
-		NSDictionary *attributes = @{ NSFontNameAttribute: fontName, NSFontCascadeListAttribute: fallbackDescriptors };
+		attributes[NSFontNameAttribute] = fontName;
 
 		NSFont *font = [NSFont fontWithDescriptor:[NSFontDescriptor fontDescriptorWithFontAttributes:attributes] size:fontSize];
 		if (font != nil) return font;
 
 		if (remainingFontNames.count == 0) break;
 
+		if (fallbackDescriptors.count > 0) {
+			NSString *topName = [fallbackDescriptors[0] fontAttributes][NSFontAttributeName];
+			if ([topName isEqual:fontName]) [fallbackDescriptors removeObjectAtIndex:0];
+		}
+
 		// Try the next font in the list.
 		fontName = remainingFontNames[0];
 		[remainingFontNames removeObjectAtIndex:0];
-		[fallbackDescriptors removeObjectAtIndex:0];
 	}
 
 	return nil;


### PR DESCRIPTION
Fixes a crash where the text renderer would look for a glyph in one of the font descriptors from the cascade list, but the font was nonexistent.
