### PR TITLE
RBLViewControllerAddition replaces wrong method.

### DIFF
--- a/Rebel/NSView+RBLViewControllerAdditions.m
+++ b/Rebel/NSView+RBLViewControllerAdditions.m
@@ -22,7 +22,7 @@ void *kRBLViewControllerKey = &kRBLViewControllerKey;
 }
 
 -(void)setRbl_viewController:(id)newViewController {
-	[[self class] loadSupportForRBLViewControllers];
+	[NSView loadSupportForRBLViewControllers];
 	
 	if (self.rbl_viewController) {
 		NSResponder *controllerNextResponder = [self.rbl_viewController nextResponder];


### PR DESCRIPTION
If the first view you use happens to be overloading any of the method, for example viewWillMoveToWindow, the swap function will swap out the overloaded class with the custom_ version.

The swap should replace the base implementation that is provided by the NSView. This patch will force the NSView's method to be replaced instead of the overloaded method. 
