### PR TITLE
Allow the escape key if there's an interesting first responder.

### DIFF
--- a/Rebel/RBLPopover.m
+++ b/Rebel/RBLPopover.m
@@ -289,7 +289,7 @@
 			RBLPopover *strongSelf = weakSelf;
 			static NSUInteger escapeKey = 53;
 			NSResponder *firstResponder = strongSelf.popoverWindow.firstResponder;
-			BOOL anythingInterestingAsFirstResponder = [firstResponder isKindOfClass:NSTextView.class];
+			BOOL anythingInterestingAsFirstResponder = [firstResponder isKindOfClass:NSText.class];
 			if (event.type == NSKeyUp && event.keyCode == escapeKey && (!anythingInterestingAsFirstResponder || strongSelf.behavior == RBLPopoverBehaviorTransient)) {
 				[strongSelf close];
 				return nil;


### PR DESCRIPTION
Example: a search field in a popover. Escape should clear the contents of the search field, not close the popover.
