### PR TITLE
Add a prefix to RBLTableCellView

### DIFF
--- a/Rebel/RBLTableCellView.h
+++ b/Rebel/RBLTableCellView.h
@@ -19,6 +19,6 @@
 //
 // Either way, the cell will not have a superview during this
 // time and will be in an enqueued state.
-- (void)prepareForReuse;
+- (void)rbl_prepareForReuse;
 
 @end

--- a/Rebel/RBLTableCellView.m
+++ b/Rebel/RBLTableCellView.m
@@ -12,13 +12,13 @@
 
 - (void)viewDidMoveToSuperview {
 	if (self.superview == nil) {
-		[self prepareForReuse];
+		[self rbl_prepareForReuse];
 	}
 	
 	[super viewDidMoveToSuperview];
 }
 
-- (void)prepareForReuse {
+- (void)rbl_prepareForReuse {
 	
 }
 


### PR DESCRIPTION
Note that I did not deprecate the old method, I simply renamed it.

Fixes #102.
