### PR TITLE
It's polite for RBLPopover to let the view layout first

### DIFF
--- a/Rebel/RBLPopover.m
+++ b/Rebel/RBLPopover.m
@@ -145,6 +145,8 @@
 	
 	NSRect windowRelativeRect = [positioningView convertRect:positioningRect toView:nil];
 	CGRect screenPositioningRect = [positioningView.window convertRectToScreen:windowRelativeRect];
+	
+	[self.contentViewController.view layoutSubtreeIfNeeded];
 	self.originalViewSize = self.contentViewController.view.frame.size;
 	CGSize contentViewSize = (CGSizeEqualToSize(self.contentSize, CGSizeZero) ? self.contentViewController.view.frame.size : self.contentSize);
 	


### PR DESCRIPTION
Without this, views with Auto Layout might not display properly. Basically, you can't trust the view's frame until it's had a chance to layout.
