### PR TITLE
Make RBLPopover's view customizable

### DIFF
--- a/Rebel/RBLPopover.h
+++ b/Rebel/RBLPopover.h
@@ -54,7 +54,7 @@ typedef void (^RBLPopoverDelegateBlock)(RBLPopover *popover);
 
 // The popover's background view. You may set your own view, which is useful for
 // customizing the appearance of the popover.
-@property (nonatomic, strong) RBLPopoverBackgroundView *backgroundView;
+@property (nonatomic, strong, readonly) RBLPopoverBackgroundView *backgroundView;
 
 // The size that, when displayed, the popover's content should be.
 // Passing `CGSizeZero` uses the size of the `contentViewController`'s view.
@@ -99,10 +99,13 @@ typedef void (^RBLPopoverDelegateBlock)(RBLPopover *popover);
 // Defaults to `NO`.
 @property (nonatomic, assign) BOOL canBecomeKey;
 
+// Returns a newly initialised `RBLPopover` with a `RBLPopoverBackgroundView`.
+- (instancetype)initWithContentViewController:(NSViewController *)viewController;
+
 // Designated initialiser.
 //
 // Returns a newly initialised `RBLPopover`.
-- (instancetype)initWithContentViewController:(NSViewController *)viewController;
+- (instancetype)initWithContentViewController:(NSViewController *)viewController backgroundView:(RBLPopoverBackgroundView *)backgroundView;
 
 // Displays the popover
 //

--- a/Rebel/RBLPopover.m
+++ b/Rebel/RBLPopover.m
@@ -120,18 +120,24 @@
 @implementation RBLPopover
 
 - (instancetype)initWithContentViewController:(NSViewController *)viewController {
+	RBLPopoverBackgroundView *view = [[RBLPopoverBackgroundView alloc] initWithFrame:NSZeroRect];
+	return [self initWithContentViewController:viewController backgroundView:view];
+}
+
+- (instancetype)initWithContentViewController:(NSViewController *)viewController backgroundView:(RBLPopoverBackgroundView *)backgroundView {
 	self = [super init];
 	if (self == nil)
 		return nil;
 	
 	_contentViewController = viewController;
+	_backgroundView = backgroundView;
 	_clippingView = [[RBLPopoverClippingView alloc] initWithFrame:NSZeroRect];
 	_behavior = RBLPopoverBehaviorApplicationDefined;
 	_animates = YES;
 	_fadeDuration = 0.3;
-	
-	self.backgroundView = [[RBLPopoverBackgroundView alloc] initWithFrame:NSZeroRect];
 
+	[self.backgroundView addSubview:self.clippingView];
+	
 	return self;
 }
 
@@ -148,15 +154,6 @@
 
 #pragma mark -
 #pragma mark Showing
-
-- (void)setBackgroundView:(RBLPopoverBackgroundView *)backgroundView {
-	if ([backgroundView isEqual:self.backgroundView]) return;
-	
-	[self.clippingView removeFromSuperview];
-	_backgroundView = backgroundView;
-	self.clippingView.frame = self.backgroundView.bounds;
-	[backgroundView addSubview:self.clippingView];
-}
 
 - (void)showRelativeToRect:(CGRect)positioningRect ofView:(NSView *)positioningView preferredEdge:(CGRectEdge)preferredEdge {
 	if (CGRectEqualToRect(positioningRect, CGRectZero)) {


### PR DESCRIPTION
This replaces #119 and makes `RBLPopover` more customizable by changing the way its `backgroundView` works. It also adds an `arrowSize` property to the background view.

/cc @dannygreg 
