### PR TITLE
Don't call -layoutSubtreeIfNeeded in RBLPopover

### DIFF
--- a/Rebel/RBLPopover.m
+++ b/Rebel/RBLPopover.m
@@ -159,7 +159,6 @@
 	NSRect windowRelativeRect = [positioningView convertRect:positioningRect toView:nil];
 	CGRect screenPositioningRect = [positioningView.window convertRectToScreen:windowRelativeRect];
 	
-	[self.contentViewController.view layoutSubtreeIfNeeded];
 	self.originalViewSize = self.contentViewController.view.frame.size;
 	CGSize contentViewSize = (CGSizeEqualToSize(self.contentSize, CGSizeZero) ? self.contentViewController.view.frame.size : self.contentSize);
 	


### PR DESCRIPTION
Evidently it turns on Auto Layout, which may not be wanted. While this was necessary to work with Auto Layout before (#118), it’s no longer necessary because the popover resizes correctly after #122.
