### PR TITLE
Override -hitTest: on a popover's clipping view

### DIFF
--- a/Rebel/RBLPopover.m
+++ b/Rebel/RBLPopover.m
@@ -97,6 +97,10 @@ static CGFloat RBLRectsGetMedianY(CGRect r1, CGRect r2) {
 	self.clippingPath = NULL;
 }
 
+- (NSView *)hitTest:(NSPoint)aPoint {
+	return nil;
+}
+
 - (void)setClippingPath:(CGPathRef)clippingPath {
 	if (clippingPath == _clippingPath) return;
 	


### PR DESCRIPTION
The clipping view should never be hit. It’s only there to clip. Without this, Ctrl-clicking in a NSTableView or NSOutlineView in the content view will not work (even though right-clicking does).
