### PR TITLE
Don't care if our parent window is key.

### DIFF
--- a/Rebel/RBLPopover.m
+++ b/Rebel/RBLPopover.m
@@ -331,7 +331,7 @@ static CGFloat RBLRectsGetMedianY(CGRect r1, CGRect r2) {
 				shouldClose = !mouseInPopoverWindow;
 			} else {
 				BOOL inParentWindow = NSPointInRect(NSEvent.mouseLocation, strongSelf.popoverWindow.parentWindow.frame);
-				shouldClose = strongSelf.popoverWindow.parentWindow.isKeyWindow && inParentWindow && !mouseInPopoverWindow;
+				shouldClose = inParentWindow && !mouseInPopoverWindow;
 			}
 			
 			if (shouldClose) [strongSelf close];


### PR DESCRIPTION
This check is confusing. It lets us make the parent window key without dismissing the popover, which seems contrary to the docs for `RBLPopoverBehaviorSemiTransient`:

```
Closes the popover only if there is a 
mouse up within the popover's parent 
window or `esc` is pressed.
```
