### PR TITLE
Use windowNumberAtPoint: to determine if a mouse event is on a window.

### DIFF
--- a/Rebel/RBLPopover.m
+++ b/Rebel/RBLPopover.m
@@ -332,7 +332,7 @@ static CGFloat RBLRectsGetMedianY(CGRect r1, CGRect r2) {
 			RBLPopover *strongSelf = weakSelf;
 			if (strongSelf.popoverWindow == nil) return;
 			BOOL shouldClose = NO;
-			BOOL mouseInPopoverWindow = NSPointInRect(NSEvent.mouseLocation, strongSelf.popoverWindow.frame);
+			BOOL mouseInPopoverWindow = ([NSWindow windowNumberAtPoint:NSEvent.mouseLocation belowWindowWithWindowNumber:0] == strongSelf.popoverWindow.windowNumber);
 			if (strongSelf.behavior == RBLPopoverBehaviorTransient) {
 				shouldClose = !mouseInPopoverWindow;
 			} else {


### PR DESCRIPTION
If we've presented a modal window from a popover, we don't want it to be dismissed when the modal window is moved ... the mouseUp event from moving the modal will cause the popover to be closed. :cry: 

Not yet convinced that this is the best solution, so I will try out a few other ideas.

**UPDATE:** Now using `windowNumberAtPoint:` which can tell us which window a mouse event will hit, instead of just checking if the mouse event is within the window's frame.
