### PR TITLE
RBLScrolling takes contentInsets into account

### DIFF
--- a/Rebel/RBLScrolling.m
+++ b/Rebel/RBLScrolling.m
@@ -11,6 +11,11 @@
 BOOL RBLScrollRectInViewToVisible(NSView *view, NSRect rect) {
 	NSScrollView *scrollView = view.enclosingScrollView;
 	NSRect visibleRect = view.visibleRect;
+
+	NSEdgeInsets insets = NSEdgeInsetsMake(0, 0, 0, 0);
+	if ([scrollView respondsToSelector:@selector(contentInsets)]) {
+		insets = scrollView.contentInsets;
+	}
 	
 	void (^scrollToY)(CGFloat) = ^(CGFloat y) {
 		NSPoint pointToScrollTo = NSMakePoint(0, y);
@@ -20,12 +25,12 @@ BOOL RBLScrollRectInViewToVisible(NSView *view, NSRect rect) {
 	};
 	
 	if (NSMinY(rect) < NSMinY(visibleRect)) {
-		scrollToY(NSMinY(rect));
+		scrollToY(NSMinY(rect) - insets.top);
 		return YES;
 	}
 	
 	if (NSMaxY(rect) > NSMaxY(visibleRect)) {
-		scrollToY(NSMaxY(rect) - NSHeight(visibleRect));
+		scrollToY(NSMaxY(rect) - NSHeight(visibleRect) + insets.bottom);
 		return YES;
 	}
 	


### PR DESCRIPTION
As of 10.10 NSScrollView has a contentInsets property that is useful alongside translucent toolbars and title bars so that, similarly to iOS 7+, scroll view content can scroll underneath the blurred bar. The current implementation of `RBLScrollRectInViewToVisible` causes cell views not to be fully visible when scrolled fully to the top or bottom. This change takes these insets into account when scrolling with `RBLScrollRectInViewToVisible` so that table/outline cell views remain fully visible when at the top or bottom of the scroll view.
## Examples

In this app I've set the contentInsets to be equal to the height of each of the visual effect views that are the header and footer. In both of these recordings I first scroll with the arrow keys, and then with the mouse. Notice that the before recording doesn't make the first and last cell views fully visible when scrolling with keys.
### Before

![rebel-before](https://cloud.githubusercontent.com/assets/594059/3853080/543b7512-1ebc-11e4-8d0d-55346cf4eac0.gif)
### After

![rebel-after](https://cloud.githubusercontent.com/assets/594059/3853084/59304ca0-1ebc-11e4-960e-ee9172de7e3d.gif)
