### PR TITLE
Prefix the capInsets property

### DIFF
--- a/Rebel/NSImage+RBLResizableImageAdditions.m
+++ b/Rebel/NSImage+RBLResizableImageAdditions.m
@@ -15,7 +15,7 @@
 	RBLResizableImage *image = [[RBLResizableImage alloc] initWithSize:self.size];
 	[image addRepresentations:self.representations];
 
-	image.capInsets = capInsets;
+	image.rbl_capInsets = capInsets;
 	return image;
 }
 

--- a/Rebel/RBLResizableImage.h
+++ b/Rebel/RBLResizableImage.h
@@ -18,6 +18,6 @@
 //
 // Any portion of the image not covered by end caps will be tiled when the image
 // is drawn.
-@property (nonatomic, assign) NSEdgeInsets capInsets;
+@property (nonatomic, assign) NSEdgeInsets rbl_capInsets;
 
 @end

--- a/Rebel/RBLResizableImage.m
+++ b/Rebel/RBLResizableImage.m
@@ -32,7 +32,7 @@
 	CGFloat widthScale = CGImageGetWidth(image) / self.size.width;
 	CGFloat heightScale = CGImageGetHeight(image) / self.size.height;
 
-	NSEdgeInsets insets = self.capInsets;
+	NSEdgeInsets insets = self.rbl_capInsets;
 
 	// TODO: Cache the nine-part images for this common case of wanting to draw
 	// the whole source image.
@@ -147,7 +147,7 @@
 
 - (id)copyWithZone:(NSZone *)zone {
 	RBLResizableImage *image = [super copyWithZone:zone];
-	image.capInsets = self.capInsets;
+	image.rbl_capInsets = self.rbl_capInsets;
 	return image;
 }
 
@@ -157,7 +157,7 @@
 	self = [super initWithCoder:coder];
 	if (self == nil) return nil;
 
-	self.capInsets = NSEdgeInsetsMake(
+	self.rbl_capInsets = NSEdgeInsetsMake(
 		[coder decodeDoubleForKey:@"capInsetTop"],
 		[coder decodeDoubleForKey:@"capInsetLeft"],
 		[coder decodeDoubleForKey:@"capInsetBottom"],
@@ -170,10 +170,10 @@
 - (void)encodeWithCoder:(NSCoder *)coder {
 	[super encodeWithCoder:coder];
 
-	[coder encodeDouble:self.capInsets.top forKey:@"capInsetTop"];
-	[coder encodeDouble:self.capInsets.left forKey:@"capInsetLeft"];
-	[coder encodeDouble:self.capInsets.bottom forKey:@"capInsetBottom"];
-	[coder encodeDouble:self.capInsets.right forKey:@"capInsetRight"];
+	[coder encodeDouble:self.rbl_capInsets.top forKey:@"capInsetTop"];
+	[coder encodeDouble:self.rbl_capInsets.left forKey:@"capInsetLeft"];
+	[coder encodeDouble:self.rbl_capInsets.bottom forKey:@"capInsetBottom"];
+	[coder encodeDouble:self.rbl_capInsets.right forKey:@"capInsetRight"];
 }
 
 #pragma mark NSObject
@@ -183,8 +183,8 @@
 	if (![image isKindOfClass:RBLResizableImage.class]) return NO;
 	if (![super isEqual:image]) return NO;
 
-	NSEdgeInsets a = self.capInsets;
-	NSEdgeInsets b = image.capInsets;
+	NSEdgeInsets a = self.rbl_capInsets;
+	NSEdgeInsets b = image.rbl_capInsets;
 
 	if (fabs(a.left - b.left) > 0.1) return NO;
 	if (fabs(a.top - b.top) > 0.1) return NO;
@@ -195,7 +195,7 @@
 }
 
 - (NSString *)description {
-	NSEdgeInsets insets = self.capInsets;
+	NSEdgeInsets insets = self.rbl_capInsets;
 	return [NSString stringWithFormat:@"<%@: %p>{ size = %@, capInsets = (%f, %f, %f, %f) }", self.class, self, NSStringFromSize(self.size), insets.top, insets.left, insets.bottom, insets.right];
 }
 


### PR DESCRIPTION
On the 10.10 SDK, NSImage has a private declaration of the capInsets
property. This declaration squashes it.
