### PR TITLE
Pacify Xcode

### DIFF
--- a/Rebel.xcodeproj/project.pbxproj
+++ b/Rebel.xcodeproj/project.pbxproj
@@ -507,7 +507,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastTestingUpgradeCheck = 0510;
-				LastUpgradeCheck = 0510;
+				LastUpgradeCheck = 0620;
 				ORGANIZATIONNAME = GitHub;
 			};
 			buildConfigurationList = D09AE4D815C5F45200ECAD10 /* Build configuration list for PBXProject "Rebel" */;
@@ -647,6 +647,7 @@
 			baseConfigurationReference = D08BB2DD15CB307200CC9868 /* Debug.xcconfig */;
 			buildSettings = {
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				ONLY_ACTIVE_ARCH = YES;
 			};
 			name = Debug;
 		};

--- a/Rebel.xcodeproj/xcshareddata/xcschemes/Rebel.xcscheme
+++ b/Rebel.xcodeproj/xcshareddata/xcschemes/Rebel.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0610"
+   LastUpgradeVersion = "0620"
    version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
For https://github.com/jspahrsummers/xcconfigs/pull/32.

And I know what you’re thinking, “But `ONLY_ACTIVE_ARCH` is already in the xcconfig!” Yes. Well. Xcode.