### PR TITLE
Remove old code that doesn't do anything anymore

### DIFF
--- a/Rebel/RBLPopover.m
+++ b/Rebel/RBLPopover.m
@@ -472,7 +472,6 @@ static CGFloat RBLRectsGetMedianY(CGRect r1, CGRect r2) {
 	}
 	self.transientEventMonitors = nil;
 	[NSNotificationCenter.defaultCenter removeObserver:self name:NSApplicationDidResignActiveNotification object:NSApp];
-	[NSNotificationCenter.defaultCenter removeObserver:self name:NSWindowDidResignKeyNotification object:nil];
 
 	if (self.willEnterFullScreenObserver != nil && self.willExitFullScreenObserver != nil) {
 		[NSNotificationCenter.defaultCenter removeObserver:self.willEnterFullScreenObserver];


### PR DESCRIPTION
b6c2513af0b154e8f136a7dac1096007dd569cb9 added an observer for `NSWindowDidResignKeyNotification`. Most of that has been removed, but the code to remove the observer that is never added is still there.
